### PR TITLE
Add Umbrel packaging scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ VPS/Docker setup. It includes:
 - persistent wallet, database, and secret paths under `${APP_DATA_DIR}`.
 - a backend entrypoint that generates missing internal secrets on first boot and
   preserves them for future updates.
+- a browser home page with health check, POS connection details, admin console,
+  and vendor dashboard links.
 
 Validate the package locally with:
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,27 @@ Output APK: `app/build/outputs/apk/debug/app-debug.apk`
 
 > For detailed backend API usage, see [`backend/README.md`](backend/README.md).
 
+## Umbrel one-click app packaging
+
+Umbrel packaging lives in [`umbrel/`](umbrel/) and is isolated from the existing
+VPS/Docker setup. It includes:
+
+- `umbrel-app.yml` with Umbrel UI configuration for daemon RPC, admin
+  credentials, wallet name, and zero-conf mode.
+- `docker-compose.yml` wired for Umbrel's `app_proxy`.
+- persistent wallet, database, and secret paths under `${APP_DATA_DIR}`.
+- a backend entrypoint that generates missing internal secrets on first boot and
+  preserves them for future updates.
+
+Validate the package locally with:
+
+```bash
+APP_DATA_DIR="$(pwd)/.umbrel-test-data" \
+APP_PASSWORD="change-me-in-production" \
+APP_SEED="$(openssl rand -hex 32)" \
+docker compose -f umbrel/docker-compose.yml config
+```
+
 ---
 
 ## Donations

--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ APP_SEED="$(openssl rand -hex 32)" \
 docker compose -f umbrel/docker-compose.yml config
 ```
 
+Reviewers can also test through Umbrel's Community App Store flow by adding:
+
+```text
+https://github.com/ryriigh/monero-merchant-umbrel-store
+```
+
 ---
 
 ## Donations

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,5 +8,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o backend ./cmd/api
 FROM alpine:latest
 WORKDIR /app
 COPY --from=builder /app/backend .
+COPY --from=builder /app/web ./web
 EXPOSE 8080
 CMD ["./backend"]

--- a/backend/internal/core/server/routes.go
+++ b/backend/internal/core/server/routes.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"context"
+	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -74,6 +77,10 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *gorm.DB, rpcClient *
 
 	// Public routes
 	r.Group(func(r chi.Router) {
+		r.Get("/", serveWebFile("index.html"))
+		r.Get("/admin.html", serveWebFile("admin.html"))
+		r.Get("/vendor-dashboard.html", serveWebFile("vendor-dashboard.html"))
+
 		// Auth routes
 		r.Post("/auth/login-admin", authHandler.LoginAdmin)
 		r.Post("/auth/login-vendor", authHandler.LoginVendor)
@@ -125,4 +132,20 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *gorm.DB, rpcClient *
 	})
 
 	return r
+}
+
+func serveWebFile(name string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		for _, path := range []string{
+			filepath.Join("web", name),
+			filepath.Join("/app", "web", name),
+			filepath.Join("backend", "web", name),
+		} {
+			if _, err := os.Stat(path); err == nil {
+				http.ServeFile(w, r, path)
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}
 }

--- a/backend/web/admin.html
+++ b/backend/web/admin.html
@@ -28,7 +28,7 @@
 </head>
 <body>
 <h1>XMRpos Admin API Test Console</h1>
-<p class="muted">All requests are proxied to <code>xmr1.twed.org:8080</code>.</p>
+<p class="muted">All requests use this app's current origin, so it works on umbrel.local, Tor, and Tailscale URLs.</p>
 
 <div class="wrap">
 

--- a/backend/web/index.html
+++ b/backend/web/index.html
@@ -2,379 +2,78 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>XMRpos Vendor/POS API Test Console</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Monero Merchant</title>
   <style>
-    *,*::before,*::after{box-sizing:border-box}
-    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;margin:24px;max-width:1100px;background:#282A36;color:#F8F8F2}
-    h1,h2{margin:0 0 8px;color:#F8F8F2}
-    .wrap{display:grid;gap:16px}
-    .card{background:#303347;border:1px solid #44475A;border-radius:10px;padding:18px;box-shadow:0 6px 14px rgba(0,0,0,0.25)}
-    .card > * + *{margin-top:16px}
-    label{display:block;margin:0 0 6px;color:#F8F8F2;font-weight:500}
-    input,textarea,button,select{width:100%;padding:10px 12px;font-size:14px;border:1px solid #6272A4;border-radius:6px;background:#44475A;color:#F8F8F2}
-    input:focus,textarea:focus,select:focus{outline:2px solid #8BE9FD;outline-offset:1px}
-    button{background:#6272A4;border:1px solid #6272A4;font-weight:600;cursor:pointer;transition:background 0.2s,border-color 0.2s}
-    button:hover{background:#6f7bc7;border-color:#6f7bc7}
-    textarea{min-height:96px;font-family:ui-monospace,Consolas,monospace}
-    pre{overflow:auto;white-space:pre-wrap;word-wrap:anywhere;background:#21222C;border:1px solid #44475A;padding:12px;border-radius:8px;color:#F8F8F2}
-    .row{display:grid;grid-template-columns:180px 1fr;gap:16px;align-items:center}
-    .grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-    .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
-    .grid2 > div,.grid3 > div{display:flex;flex-direction:column;gap:6px}
-    .ok{color:#50FA7B}
-    .err{color:#FF5555}
-    .muted{color:#6272A4}
-    a{color:#8BE9FD}
-    code{background:#44475A;color:#F8F8F2;border-radius:4px;padding:0 4px}
-    .actions{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:16px}
-    .section-title{margin:16px 0 8px;font-size:20px;font-weight:600;color:#F8F8F2}
+    :root{--bg:#1b1d26;--card:#24283b;--muted:#a9b1d6;--text:#f8f8f2;--line:#414868;--accent:#ff6600;--ok:#9ece6a;--err:#f7768e}
+    *{box-sizing:border-box}
+    body{margin:0;min-height:100vh;background:linear-gradient(135deg,#151720,#24283b);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
+    main{max-width:1100px;margin:0 auto;padding:40px 20px}
+    header{display:grid;gap:12px;margin-bottom:24px}
+    h1{font-size:40px;margin:0}
+    p{color:var(--muted);line-height:1.55}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px}
+    .card{background:rgba(36,40,59,.94);border:1px solid var(--line);border-radius:16px;padding:20px;box-shadow:0 10px 30px rgba(0,0,0,.25)}
+    .card h2{margin:0 0 8px;font-size:20px}
+    a.button,button{display:inline-flex;align-items:center;justify-content:center;gap:8px;width:100%;margin-top:12px;padding:12px 14px;border-radius:10px;border:1px solid var(--accent);background:var(--accent);color:white;text-decoration:none;font-weight:700;cursor:pointer}
+    a.secondary{border-color:var(--line);background:#30364d}
+    code,pre{background:#161923;border:1px solid var(--line);border-radius:8px;color:#f8f8f2}
+    code{padding:2px 6px}
+    pre{padding:12px;white-space:pre-wrap;word-break:break-word;min-height:72px}
+    .status{font-weight:700}.ok{color:var(--ok)}.err{color:var(--err)}
   </style>
 </head>
 <body>
-<h1>XMRpos Vendor/POS API Test Console</h1>
-<p class="muted">All requests are proxied to <code>xmr1.twed.org:8080</code>.</p>
+<main>
+  <header>
+    <h1>Monero Merchant</h1>
+    <p>Self-hosted Monero point-of-sale backend for Umbrel. Use this home page to verify service health, open the admin console, and copy connection details for Android POS clients.</p>
+  </header>
 
-<div class="wrap">
-
-  <!-- Health -->
-  <div class="card">
-    <h2>Status</h2>
-    <button id="btn-health">Check Health</button>
-    <pre id="out-health"></pre>
-  </div>
-
-  <!-- Vendor: signup -->
-  <div class="card">
-    <h2>Vendor Signup</h2>
-    <div class="grid2">
-      <div>
-        <label>Username</label><input id="v-name" placeholder="vendor-name" />
-      </div>
-      <div>
-        <label>Password</label><input id="v-pass" type="password" placeholder="" />
-      </div>
+  <section class="grid">
+    <div class="card">
+      <h2>Service status</h2>
+      <p>Checks the backend <code>/misc/health</code> endpoint through the same Umbrel app URL your POS devices use.</p>
+      <button id="check">Check health</button>
+      <pre id="health">Not checked yet.</pre>
     </div>
-    <label>Monero subaddress</label>
-    <textarea id="v-subaddr" placeholder="8A6shd5c..."></textarea>
-    <label>Invite code</label>
-    <input id="v-invite" placeholder="invite code" />
-    <div class="actions">
-      <button id="btn-v-create">Create Account</button>
+    <div class="card">
+      <h2>Admin command center</h2>
+      <p>Login with the Umbrel app username/password, view wallet balance, create vendor invites, list vendors, and trigger transfers.</p>
+      <a class="button" href="/admin.html">Open admin console</a>
     </div>
-    <pre id="out-v-create"></pre>
-  </div>
-
-  <!-- Vendor: login -->
-  <div class="card">
-    <h2>Vendor Login</h2>
-    <div class="grid2">
-      <div><label>Username</label><input id="lv-name" placeholder="" /></div>
-      <div><label>Password</label><input id="lv-pass" type="password" placeholder="" /></div>
+    <div class="card">
+      <h2>Vendor dashboard</h2>
+      <p>Browser dashboard for vendor balance, POS device management, withdrawals, and transaction export.</p>
+      <a class="button secondary" href="/vendor-dashboard.html">Open vendor dashboard</a>
     </div>
-    <button id="btn-v-login">Login</button>
-    <pre id="out-v-auth"></pre>
-  </div>
-
-  <!-- Vendor: balance -->
-  <div class="card">
-    <h2>Vendor Balance</h2>
-    <button id="btn-v-balance">Fetch Balance</button>
-    <pre id="out-v-balance" class="muted"></pre>
-  </div>
-
-  <br />
-  <h2 class="section-title">POS Calls</h2>
-
-  <!-- POS: create under vendor -->
-  <div class="card">
-    <h2>Register POS</h2>
-    <div class="grid2">
-      <div><label>POS name</label><input id="pos-name" placeholder="" /></div>
-      <div><label>POS password</label><input id="pos-pass" type="password" placeholder="" /></div>
+    <div class="card">
+      <h2>POS connection details</h2>
+      <p>Use the current page origin as the backend URL for Android POS clients on LAN, Tor, or Tailscale.</p>
+      <pre id="details"></pre>
     </div>
-    <button id="btn-pos-create">Register</button>
-    <pre id="out-pos-create"></pre>
-  </div>
-
-  <!-- POS: login -->
-  <div class="card">
-    <h2>POS Login</h2>
-    <div class="grid3">
-      <div><label>Vendor ID</label><input id="lp-vendor-id" type="number" placeholder="" /></div>
-      <div><label>POS name</label><input id="lp-name" placeholder="" /></div>
-      <div><label>POS password</label><input id="lp-pass" type="password" placeholder="" /></div>
-    </div>
-    <button id="btn-pos-login">Login</button>
-    <pre id="out-pos-auth"></pre>
-  </div>
-
-  <!-- POS: make transaction -->
-  <div class="card">
-    <h2>Make Transaction</h2>
-    <div class="grid2">
-      <div>
-        <label>Amount (XMR)</label>
-        <input id="tx-amount" type="number" step="0.0001" min="0" placeholder="0.1234" />
-      </div>
-      <div>
-        <label>Description</label>
-        <input id="tx-desc" placeholder="Coffee order" />
-      </div>
-    </div>
-    <button id="btn-pos-create-tx">Create Transaction</button>
-    <pre id="out-pos-create-tx" class="muted"></pre>
-  </div>
-
-  <!-- POS: transaction lookup -->
-  <div class="card">
-    <h2>Lookup Transaction</h2>
-    <div class="row">
-      <label>Transaction ID</label><input id="tx-id" type="number" placeholder="" />
-    </div>
-    <button id="btn-pos-refresh">Refresh POS Token</button>
-    <button id="btn-pos-tx">Get Transaction</button>
-    <pre id="out-pos-tx" class="muted"></pre>
-  </div>
-
-  <!-- POS: export transactions -->
-  <div class="card">
-    <h2>Export Transactions</h2>
-    <p class="muted">Export confirmed transactions as CSV</p>
-    <button id="btn-pos-export">Export</button>
-    <pre id="out-pos-export" class="muted"></pre>
-  </div>
-
-</div>
-
+  </section>
+</main>
 <script>
-const $ = (id)=>document.getElementById(id);
-const pretty = (v)=> typeof v === "string" ? v : JSON.stringify(v, null, 2);
-const showError = (id, err)=>{ $(id).textContent = err?.message || String(err); };
+const details = document.getElementById("details");
+details.textContent = [
+  `Backend URL: ${window.location.origin}`,
+  "Admin username: admin unless changed in Umbrel app config",
+  "Admin password: Umbrel app password unless changed in app config",
+  "Health endpoint: /misc/health"
+].join("\n");
 
-let vendor = { access:null, refresh:null, tokenType:"Bearer" };
-let pos    = { access:null, refresh:null, tokenType:"Bearer" };
-
-const outVendorBalance = $("out-v-balance");
-const txIdInput = $("tx-id");
-const btnPosTx = $("btn-pos-tx");
-const outPosTx = $("out-pos-tx");
-const outPosCreateTx = $("out-pos-create-tx");
-const outPosExport = $("out-pos-export");
-const txAmountInput = $("tx-amount");
-const txDescInput = $("tx-desc");
-const updateTxLabel = ()=>{
-  const raw = txIdInput.value.trim();
-  btnPosTx.textContent = raw ? `Get Transaction #${raw}` : "Get Transaction";
-};
-txIdInput.addEventListener("input", updateTxLabel);
-updateTxLabel();
-
-// --- Health ---
-$("btn-health").onclick = async ()=>{
+document.getElementById("check").onclick = async () => {
+  const out = document.getElementById("health");
+  out.textContent = "Checking...";
   try {
-    const r = await fetch("/misc/health");
-    const ct = r.headers.get("content-type")||"";
-    $("out-health").textContent = pretty(ct.includes("json")? await r.json(): await r.text());
-  } catch (err) {
-    showError("out-health", err);
+    const response = await fetch("/misc/health", {headers: {"accept": "application/json"}});
+    const text = await response.text();
+    out.innerHTML = `<span class="${response.ok ? "ok" : "err"}">HTTP ${response.status}</span>\n${text}`;
+  } catch (error) {
+    out.innerHTML = `<span class="err">Request failed</span>\n${error && error.message ? error.message : String(error)}`;
   }
 };
-
-// --- Vendor create ---
-$("btn-v-create").onclick = async ()=>{
-  const body = {
-    name: $("v-name").value.trim(),
-    password: $("v-pass").value.trim(),
-    monero_subaddress: $("v-subaddr").value.trim(),
-    invite_code: $("v-invite").value.trim()
-  };
-  try {
-    const r = await fetch("/vendor/create", {
-      method:"POST",
-      headers:{ "Content-Type":"application/json" },
-      body: JSON.stringify(body)
-    });
-    const out = await r.json().catch(()=> ({}));
-    $("out-v-create").textContent = pretty(out);
-  } catch (err) {
-    showError("out-v-create", err);
-  }
-};
-
-// --- Vendor login ---
-$("btn-v-login").onclick = async ()=>{
-  const body = { name:$("lv-name").value.trim(), password:$("lv-pass").value.trim() };
-  try {
-    const r = await fetch("/auth/login-vendor", { method:"POST", headers:{ "Content-Type":"application/json" }, body: JSON.stringify(body) });
-    const data = await r.json().catch(()=> ({}));
-    vendor.access  = data.access_token || null;
-    vendor.refresh = data.refresh_token || null;
-    vendor.tokenType = data.token_type ? String(data.token_type) : vendor.tokenType;
-    $("out-v-auth").textContent = pretty(data);
-  } catch (err) {
-    showError("out-v-auth", err);
-  }
-};
-
-$("btn-v-balance").onclick = async ()=>{
-  try {
-    const headers = vendor.access ? { Authorization: `${vendor.tokenType} ${vendor.access}` } : {};
-    const r = await fetch("/vendor/balance", { headers });
-    const data = await r.json().catch(()=> ({}));
-    outVendorBalance.textContent = pretty(data);
-    outVendorBalance.classList.remove("muted", "err");
-  } catch (err) {
-    outVendorBalance.classList.remove("muted");
-    outVendorBalance.classList.add("err");
-    showError("out-v-balance", err);
-  }
-};
-
-// --- POS create under vendor ---
-$("btn-pos-create").onclick = async ()=>{
-  const body = { name:$("pos-name").value.trim(), password:$("pos-pass").value.trim() };
-  try {
-    const r = await fetch("/vendor/create-pos", {
-      method:"POST",
-      headers: Object.assign({ "Content-Type":"application/json" }, vendor.access ? { Authorization:`${vendor.tokenType} ${vendor.access}` } : {}),
-      body: JSON.stringify(body)
-    });
-    const data = await r.json().catch(()=> ({}));
-    $("out-pos-create").textContent = pretty(data);
-  } catch (err) {
-    showError("out-pos-create", err);
-  }
-};
-
-// --- POS login / refresh ---
-$("btn-pos-login").onclick = async ()=>{
-  const body = { name:$("lp-name").value.trim(), password:$("lp-pass").value.trim(), vendor_id: Number($("lp-vendor-id").value || 0) };
-  try {
-    const r = await fetch("/auth/login-pos", { method:"POST", headers:{ "Content-Type":"application/json" }, body: JSON.stringify(body) });
-    const data = await r.json().catch(()=> ({}));
-    pos.access  = data.access_token || null;
-    pos.refresh = data.refresh_token || null;
-    pos.tokenType = data.token_type ? String(data.token_type) : pos.tokenType;
-    $("out-pos-auth").textContent = pretty(data);
-  } catch (err) {
-    showError("out-pos-auth", err);
-  }
-};
-
-$("btn-pos-refresh").onclick = async ()=>{
-  if (!pos.refresh) { $("out-pos-auth").textContent = "No POS refresh_token."; return; }
-  try {
-    const r = await fetch("/auth/refresh", { method:"POST", headers:{ "Content-Type":"application/json" }, body: JSON.stringify({ refresh_token: pos.refresh }) });
-    const data = await r.json().catch(()=> ({}));
-    pos.access  = data.access_token  || pos.access;
-    pos.refresh = data.refresh_token || pos.refresh;
-    pos.tokenType = data.token_type ? String(data.token_type) : pos.tokenType;
-    $("out-pos-auth").textContent = pretty(data);
-  } catch (err) {
-    showError("out-pos-auth", err);
-  }
-};
-
-$("btn-pos-tx").onclick = async ()=>{
-  const raw = txIdInput.value.trim();
-  const id = Number.isFinite(Number(raw)) ? parseInt(raw, 10) : NaN;
-  if (!Number.isInteger(id) || id <= 0) {
-    outPosTx.textContent = "Transaction id must be a positive integer.";
-    outPosTx.classList.remove("muted");
-    outPosTx.classList.add("err");
-    return;
-  }
-  if (!pos.access) {
-    outPosTx.textContent = "POS access token not set. Login POS first.";
-    outPosTx.classList.remove("muted");
-    outPosTx.classList.add("err");
-    return;
-  }
-  try {
-    const r = await fetch(`/pos/transaction/${id}`, { headers: { Authorization:`${pos.tokenType} ${pos.access}` } });
-    const data = await r.json().catch(()=> ({}));
-    outPosTx.textContent = `Status ${r.status}\n${pretty(data)}`;
-    outPosTx.classList.remove("muted", "err");
-    if (!r.ok) {
-      outPosTx.classList.add("err");
-    }
-  } catch (err) {
-    outPosTx.classList.remove("muted");
-    outPosTx.classList.add("err");
-    showError("out-pos-tx", err);
-  }
-};
-
-$("btn-pos-create-tx").onclick = async ()=>{
-  if (!pos.access) {
-    outPosCreateTx.textContent = "POS access token not set. Login POS first.";
-    outPosCreateTx.classList.remove("muted");
-    outPosCreateTx.classList.add("err");
-    return;
-  }
-  const amountXmr = Number(txAmountInput.value);
-  if (!Number.isFinite(amountXmr) || amountXmr <= 0) {
-    outPosCreateTx.textContent = "Enter a valid positive XMR amount.";
-    outPosCreateTx.classList.remove("muted");
-    outPosCreateTx.classList.add("err");
-    return;
-  }
-  const amountAtomic = Math.round(amountXmr * 1e12);
-  const body = {
-    amount: amountAtomic,
-    amount_in_currency: 1,
-    currency: "USD",
-    description: txDescInput.value.trim() || null
-  };
-  try {
-    const r = await fetch("/pos/create-transaction", {
-      method:"POST",
-      headers:{
-        "Content-Type":"application/json",
-        Authorization:`${pos.tokenType} ${pos.access}`
-      },
-      body: JSON.stringify(body)
-    });
-    const data = await r.json().catch(()=> ({}));
-    outPosCreateTx.textContent = `Status ${r.status}\n${pretty(data)}`;
-    outPosCreateTx.classList.remove("muted", "err");
-    if (!r.ok) outPosCreateTx.classList.add("err");
-  } catch (err) {
-    outPosCreateTx.classList.remove("muted");
-    outPosCreateTx.classList.add("err");
-    showError("out-pos-create-tx", err);
-  }
-};
-
-$("btn-pos-export").onclick = async ()=>{
-  if (!pos.access) {
-    outPosExport.textContent = "POS access token not set. Login POS first.";
-    outPosExport.classList.remove("muted", "ok");
-    outPosExport.classList.add("err");
-    return;
-  }
-  try {
-    const r = await fetch("/pos/export", {
-      headers: { Authorization: `${pos.tokenType} ${pos.access}` }
-    });
-    const data = await r.json().catch(()=> ({}));
-    outPosExport.textContent = `Status ${r.status}\n${pretty(data)}`;
-    outPosExport.classList.remove("err", "ok");
-    if (!r.ok) {
-      outPosExport.classList.remove("muted");
-      outPosExport.classList.add("err");
-    } else {
-      outPosExport.classList.remove("muted");
-      outPosExport.classList.add("ok");
-    }
-  } catch (err) {
-    outPosExport.classList.remove("muted", "ok");
-    outPosExport.classList.add("err");
-    showError("out-pos-export", err);
-  }
-};
-
 </script>
 </body>
 </html>

--- a/backend/web/vendor-dashboard.html
+++ b/backend/web/vendor-dashboard.html
@@ -518,6 +518,7 @@ let auth = {
 
 let currentPage = 'dashboard';
 let transactions = { confirmed: [], pending: [] };
+let lastCreatedPOSConnection = null;
 
 // ============ Utilities ============
 const $ = id => document.getElementById(id);
@@ -533,6 +534,22 @@ function formatDate(dateStr) {
   if (!dateStr) return '-';
   const d = new Date(dateStr);
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+}
+
+async function copyText(text) {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const area = document.createElement('textarea');
+  area.value = text;
+  area.setAttribute('readonly', '');
+  area.style.position = 'fixed';
+  area.style.left = '-9999px';
+  document.body.appendChild(area);
+  area.select();
+  document.execCommand('copy');
+  document.body.removeChild(area);
 }
 
 // ============ API Calls ============
@@ -1116,6 +1133,55 @@ async function renderPOS(container, headerActions) {
   }
 
   container.appendChild(card);
+
+  if (lastCreatedPOSConnection) {
+    container.appendChild(createPOSConnectionCard(lastCreatedPOSConnection));
+  }
+}
+
+function createPOSConnectionCard(details) {
+  const card = document.createElement('div');
+  card.className = 'card mt-20';
+
+  const header = document.createElement('div');
+  header.className = 'card-header';
+  const title = document.createElement('h3');
+  title.className = 'card-title';
+  title.textContent = 'New POS Connection Details';
+  header.appendChild(title);
+  card.appendChild(header);
+
+  const note = document.createElement('p');
+  note.className = 'text-muted';
+  note.textContent = 'Copy these into the Android POS app now. The password is shown only because you just entered it; it is not recoverable later.';
+  card.appendChild(note);
+
+  const rows = [
+    ['Backend URL', details.backendUrl],
+    ['Login endpoint', details.loginEndpoint],
+    ['Vendor ID', String(details.vendorId)],
+    ['POS username', details.name],
+    ['POS password', details.password],
+  ];
+
+  const pre = document.createElement('pre');
+  pre.className = 'text-mono';
+  pre.textContent = rows.map(([label, value]) => `${label}: ${value}`).join('\n');
+  card.appendChild(pre);
+
+  const actions = document.createElement('div');
+  actions.className = 'mt-20';
+  const copyBtn = document.createElement('button');
+  copyBtn.className = 'btn btn-primary';
+  copyBtn.textContent = 'Copy Connection Details';
+  copyBtn.addEventListener('click', async () => {
+    await copyText(pre.textContent);
+    alert('Connection details copied.');
+  });
+  actions.appendChild(copyBtn);
+  card.appendChild(actions);
+
+  return card;
 }
 
 function renderSettings(container, headerActions) {
@@ -1346,11 +1412,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     const password = $('pos-password-input').value;
 
     try {
-      await createPOS(name, password);
+      const created = await createPOS(name, password);
+      lastCreatedPOSConnection = {
+        backendUrl: window.location.origin,
+        loginEndpoint: window.location.origin + '/auth/login-pos',
+        vendorId: created.vendor_id || auth.vendorId,
+        name,
+        password
+      };
       closeModal('create-pos-modal');
       $('pos-name-input').value = '';
       $('pos-password-input').value = '';
-      alert('POS device "' + escapeHtml(name) + '" created successfully!');
+      alert('POS device "' + name + '" created successfully. Copy the connection details from the POS Devices page.');
       navigateTo('pos');
     } catch (err) {
       alert(err.message);

--- a/umbrel/README.md
+++ b/umbrel/README.md
@@ -1,0 +1,41 @@
+# Monero Merchant on Umbrel
+
+This directory contains an isolated Umbrel packaging scaffold for Monero
+Merchant. It keeps the existing root `docker-compose.yml`, `Makefile`, and VPS
+installation path untouched while adding the one-click app-store layout required
+by issue #30.
+
+## What the app packages
+
+- `umbrel-app.yml` exposes user configuration for daemon RPC host/port, admin
+  credentials, wallet name, and zero-confirmation mode.
+- `docker-compose.yml` runs Monero wallet RPC, MoneroPay, PostgreSQL for
+  MoneroPay, PostgreSQL for the backend, and the Monero Merchant backend behind
+  Umbrel's `app_proxy`.
+- `backend-entrypoint.sh` creates a persistent `backend.env` in
+  `${APP_DATA_DIR}/config`, generating JWT and wallet secrets from
+  `/dev/urandom` on first boot and preserving them across app updates.
+- All stateful wallet, database, and secret paths live under `${APP_DATA_DIR}`.
+
+## Local smoke test
+
+From the repository root:
+
+```sh
+APP_DATA_DIR="$(pwd)/.umbrel-test-data" \
+APP_PASSWORD="change-me-in-production" \
+APP_SEED="$(openssl rand -hex 32)" \
+docker compose -f umbrel/docker-compose.yml config
+```
+
+On an Umbrel device, the UI is served through the app proxy on port `8080`.
+Remote Android POS clients should use the backend URL shown by Umbrel, e.g.
+`http://umbrel.local` on LAN or the app's Tor/Tailscale URL when those remote
+access modes are enabled.
+
+## Production follow-up before official app-store submission
+
+The compose file builds the backend from this repository so reviewers can test
+the bounty branch directly. For the official Umbrel app store, publish a pinned
+multi-arch backend image and replace the `build:` block with an immutable image
+tag plus digest.

--- a/umbrel/README.md
+++ b/umbrel/README.md
@@ -28,6 +28,19 @@ APP_SEED="$(openssl rand -hex 32)" \
 docker compose -f umbrel/docker-compose.yml config
 ```
 
+## Community App Store test URL
+
+For reviewers who want to test installation through Umbrel's Community App Store
+flow, add this store URL in umbrelOS:
+
+```text
+https://github.com/ryriigh/monero-merchant-umbrel-store
+```
+
+The community-store copy uses app id `ryriigh-monero-merchant` because Umbrel
+requires community app IDs to be prefixed by the store id. It otherwise mirrors
+this PR's app package and points back to this PR as the submission source.
+
 On an Umbrel device, the UI is served through the app proxy on port `8080`.
 Remote Android POS clients should use the backend URL shown by Umbrel, e.g.
 `http://umbrel.local` on LAN or the app's Tor/Tailscale URL when those remote

--- a/umbrel/README.md
+++ b/umbrel/README.md
@@ -15,6 +15,8 @@ by issue #30.
 - `backend-entrypoint.sh` creates a persistent `backend.env` in
   `${APP_DATA_DIR}/config`, generating JWT and wallet secrets from
   `/dev/urandom` on first boot and preserving them across app updates.
+- `/` serves a Monero Merchant home page with service health, POS connection
+  details, and links to the admin console and vendor dashboard.
 - All stateful wallet, database, and secret paths live under `${APP_DATA_DIR}`.
 
 ## Local smoke test

--- a/umbrel/backend-entrypoint.sh
+++ b/umbrel/backend-entrypoint.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -eu
+
+CONFIG_DIR="${MONERO_MERCHANT_CONFIG_DIR:-/config}"
+ENV_FILE="${CONFIG_DIR}/backend.env"
+
+rand_hex() {
+  if command -v hexdump >/dev/null 2>&1; then
+    hexdump -vn "$1" -e '1/1 "%02x"' /dev/urandom
+  else
+    od -An -N "$1" -tx1 /dev/urandom | tr -d ' \n'
+  fi
+}
+
+write_if_missing() {
+  key="$1"
+  value="$2"
+  if ! grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+  fi
+}
+
+mkdir -p "$CONFIG_DIR"
+umask 077
+touch "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+ADMIN_PASSWORD_VALUE="${ADMIN_PASSWORD:-}"
+if [ -z "$ADMIN_PASSWORD_VALUE" ] && [ -n "${APP_PASSWORD:-}" ]; then
+  ADMIN_PASSWORD_VALUE="$APP_PASSWORD"
+fi
+if [ -z "$ADMIN_PASSWORD_VALUE" ]; then
+  ADMIN_PASSWORD_VALUE="$(rand_hex 16)"
+fi
+
+DAEMON_HOST="${MONERO_DAEMON_RPC_HOSTNAME:-xmr-node.cakewallet.com}"
+DAEMON_PORT="${MONERO_DAEMON_RPC_PORT:-18081}"
+
+write_if_missing ADMIN_NAME "${ADMIN_NAME:-admin}"
+write_if_missing ADMIN_PASSWORD "$ADMIN_PASSWORD_VALUE"
+write_if_missing PORT "${PORT:-8080}"
+write_if_missing DB_HOST "${DB_HOST:-backend-db}"
+write_if_missing DB_USER "${DB_USER:-moneromerchant}"
+write_if_missing DB_PASSWORD "${DB_PASSWORD:-${APP_SEED:-$(rand_hex 16)}}"
+write_if_missing DB_NAME "${DB_NAME:-moneromerchant}"
+write_if_missing DB_PORT "${DB_PORT:-5432}"
+write_if_missing JWT_SECRET "$(rand_hex 32)"
+write_if_missing JWT_REFRESH_SECRET "$(rand_hex 32)"
+write_if_missing JWT_MONEROPAY_SECRET "$(rand_hex 32)"
+write_if_missing JWT_LWS_TOKEN "$(rand_hex 32)"
+write_if_missing MONEROPAY_BASE_URL "${MONEROPAY_BASE_URL:-http://moneropay:5000}"
+write_if_missing MONEROPAY_CALLBACK_URL "${MONEROPAY_CALLBACK_URL:-http://backend:8080/callback/}"
+write_if_missing MONERO_DAEMON_RPC_ENDPOINT "${MONERO_DAEMON_RPC_ENDPOINT:-http://${DAEMON_HOST}:${DAEMON_PORT}/json_rpc}"
+write_if_missing MONERO_WALLET_RPC_ENDPOINT "${MONERO_WALLET_RPC_ENDPOINT:-http://monero-wallet-rpc:28081/json_rpc}"
+write_if_missing MONERO_WALLET_RPC_USERNAME "${MONERO_WALLET_RPC_USERNAME:-}"
+write_if_missing MONERO_WALLET_RPC_PASSWORD "${MONERO_WALLET_RPC_PASSWORD:-}"
+write_if_missing WALLET_NAME "${WALLET_NAME:-wallet}"
+write_if_missing WALLET_PASSWORD "${WALLET_PASSWORD:-$(rand_hex 16)}"
+write_if_missing WALLET_AUTO_REFRESH_PERIOD "${WALLET_AUTO_REFRESH_PERIOD:-2}"
+
+cp "$ENV_FILE" /app/.env
+chmod 600 /app/.env
+
+set -a
+. "$ENV_FILE"
+set +a
+
+exec /app/backend

--- a/umbrel/docker-compose.yml
+++ b/umbrel/docker-compose.yml
@@ -1,0 +1,112 @@
+services:
+  app_proxy:
+    image: getumbrel/app-proxy:1.7.0@sha256:ec0de0b944a2e63d52fdd82b3760d90a35f8b442d17a8407afdee3af3e842d5a
+    environment:
+      APP_HOST: monero-merchant_backend_1
+      APP_PORT: 8080
+
+  change-vol-ownership:
+    image: alpine:3.20
+    command: "chown -R 1000:1000 /mnt/wallet"
+    volumes:
+      - ${APP_DATA_DIR}/data/wallet:/mnt/wallet
+
+  monero-wallet-rpc:
+    image: ghcr.io/sethforprivacy/simple-monero-wallet-rpc:latest
+    restart: on-failure
+    stop_grace_period: 1m
+    command: >-
+      --wallet-dir wallet
+      --disable-rpc-login
+      --rpc-bind-ip=0.0.0.0
+      --rpc-bind-port=28081
+      --confirm-external-bind
+      --daemon-host=${MONERO_DAEMON_RPC_HOSTNAME:-xmr-node.cakewallet.com}
+      --daemon-port=${MONERO_DAEMON_RPC_PORT:-18081}
+    volumes:
+      - ${APP_DATA_DIR}/data/wallet:/home/monero/wallet
+    depends_on:
+      change-vol-ownership:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail localhost:28081/json_rpc -d '{\"jsonrpc\":\"2.0\",\"id\":\"0\",\"method\":\"get_version\"}'"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+
+  moneropay-postgresql:
+    image: postgres:17-alpine
+    restart: on-failure
+    environment:
+      POSTGRES_USER: moneropay
+      POSTGRES_PASSWORD: ${APP_SEED}
+      POSTGRES_DB: moneropay
+    volumes:
+      - ${APP_DATA_DIR}/data/moneropay-postgresql:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U moneropay -d moneropay"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+
+  moneropay:
+    image: registry.gitlab.com/moneropay/moneropay:v2
+    restart: on-failure
+    environment:
+      RPC_ADDRESS: http://monero-wallet-rpc:28081/json_rpc
+      POSTGRESQL: postgresql://moneropay:${APP_SEED}@moneropay-postgresql:5432/moneropay?sslmode=disable
+      ZERO_CONF: ${MONEROPAY_ZERO_CONF:-true}
+    depends_on:
+      monero-wallet-rpc:
+        condition: service_healthy
+      moneropay-postgresql:
+        condition: service_healthy
+
+  backend-db:
+    image: postgres:16-alpine
+    restart: on-failure
+    environment:
+      POSTGRES_USER: moneromerchant
+      POSTGRES_PASSWORD: ${APP_SEED}
+      POSTGRES_DB: moneromerchant
+    volumes:
+      - ${APP_DATA_DIR}/data/backend-postgresql:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U moneromerchant -d moneromerchant"]
+      interval: 10s
+      timeout: 5s
+      retries: 18
+
+  backend:
+    build:
+      context: ..
+      dockerfile: backend/Dockerfile
+    restart: on-failure
+    stop_grace_period: 1m
+    command: ["/usr/local/bin/umbrel-backend-entrypoint"]
+    environment:
+      ADMIN_NAME: ${ADMIN_NAME:-admin}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
+      APP_PASSWORD: ${APP_PASSWORD}
+      APP_SEED: ${APP_SEED}
+      DB_HOST: backend-db
+      DB_USER: moneromerchant
+      DB_PASSWORD: ${APP_SEED}
+      DB_NAME: moneromerchant
+      DB_PORT: 5432
+      MONEROPAY_BASE_URL: http://moneropay:5000
+      MONEROPAY_CALLBACK_URL: http://backend:8080/callback/
+      MONERO_DAEMON_RPC_HOSTNAME: ${MONERO_DAEMON_RPC_HOSTNAME:-xmr-node.cakewallet.com}
+      MONERO_DAEMON_RPC_PORT: ${MONERO_DAEMON_RPC_PORT:-18081}
+      MONERO_WALLET_RPC_ENDPOINT: http://monero-wallet-rpc:28081/json_rpc
+      WALLET_NAME: ${WALLET_NAME:-wallet}
+      WALLET_AUTO_REFRESH_PERIOD: 2
+      MONERO_MERCHANT_CONFIG_DIR: /config
+    volumes:
+      - ./backend-entrypoint.sh:/usr/local/bin/umbrel-backend-entrypoint:ro
+      - ${APP_DATA_DIR}/config:/config
+    depends_on:
+      backend-db:
+        condition: service_healthy
+      moneropay:
+        condition: service_started

--- a/umbrel/exports.sh
+++ b/umbrel/exports.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export APP_MONERO_MERCHANT_BACKEND_URL="http://monero-merchant_backend_1:8080"
+export APP_MONERO_MERCHANT_MONEROPAY_URL="http://monero-merchant_moneropay_1:5000"

--- a/umbrel/umbrel-app.yml
+++ b/umbrel/umbrel-app.yml
@@ -1,0 +1,60 @@
+manifestVersion: 1
+id: monero-merchant
+category: finance
+name: Monero Merchant
+version: "0.1.0"
+tagline: Self-hosted Monero point of sale backend
+description: >-
+  Monero Merchant is a free and open-source point-of-sale backend for accepting
+  Monero payments. This Umbrel package provides a one-click backend stack with
+  MoneroPay, wallet RPC, PostgreSQL persistence, and a browser admin console so
+  merchants can connect Android POS clients without editing .env files by hand.
+developer: Monero Merchant
+website: https://github.com/Monero-Merchant/monero-merchant
+repo: https://github.com/Monero-Merchant/monero-merchant
+support: https://github.com/Monero-Merchant/monero-merchant/issues
+port: 8080
+path: ""
+defaultUsername: "admin"
+defaultPassword: "$APP_PASSWORD"
+gallery: []
+releaseNotes: ""
+submitter: Monero Merchant
+submission: ""
+user_config:
+  - id: monero_daemon_rpc_hostname
+    name: Monero daemon RPC hostname
+    description: Public or LAN Monero daemon host used by wallet-rpc.
+    type: text
+    default: xmr-node.cakewallet.com
+    env: MONERO_DAEMON_RPC_HOSTNAME
+  - id: monero_daemon_rpc_port
+    name: Monero daemon RPC port
+    description: RPC port for the configured Monero daemon.
+    type: number
+    default: 18081
+    env: MONERO_DAEMON_RPC_PORT
+  - id: admin_name
+    name: Admin username
+    description: Username for the Monero Merchant admin dashboard.
+    type: text
+    default: admin
+    env: ADMIN_NAME
+  - id: admin_password
+    name: Admin password
+    description: Optional custom admin password. Leave blank to use Umbrel's generated app password.
+    type: password
+    default: ""
+    env: ADMIN_PASSWORD
+  - id: wallet_name
+    name: Wallet name
+    description: Wallet file name stored under persistent Umbrel app data.
+    type: text
+    default: wallet
+    env: WALLET_NAME
+  - id: zero_conf
+    name: Enable zero-confirmation payments
+    description: Forward MoneroPay ZERO_CONF=true for fast point-of-sale checkout.
+    type: boolean
+    default: true
+    env: MONEROPAY_ZERO_CONF


### PR DESCRIPTION
Implements the Umbrel integration pass requested in #30.

Community App Store test URL:
- https://github.com/ryriigh/monero-merchant-umbrel-store

Reviewers can add that URL in umbrelOS via App Store -> Community App Stores -> Add Store. The store-specific app id is `ryriigh-monero-merchant` because Umbrel Community App Stores require app IDs to start with the store id. The store is now self-contained: it bundles the backend source and builds the backend image from its app directory, so the test package can be installed directly from the store URL.

What is included:
- `umbrel/umbrel-app.yml` with configurable daemon RPC host/port, admin credentials, wallet name, and zero-conf mode.
- `umbrel/docker-compose.yml` wired for Umbrel `app_proxy`, Monero wallet RPC, MoneroPay, backend PostgreSQL, backend API, and persistent `${APP_DATA_DIR}` storage.
- `umbrel/backend-entrypoint.sh` to generate missing backend JWT/wallet secrets on first boot and preserve them in `${APP_DATA_DIR}/config/backend.env`.
- Backend web UI serving: `/` now opens a Monero Merchant home page with health check, POS connection details, and links to `/admin.html` and `/vendor-dashboard.html`.
- Vendor dashboard POS connection details card: after creating a POS device, merchants can copy the backend URL, POS login endpoint, vendor ID, device name, and one-time password for Android POS setup.
- Runtime Docker image now copies `backend/web` assets so the app has a browser UI after container install.
- `umbrel/README.md` plus root README notes for local validation and Community App Store testing.

Validation performed:
- Community store `docker compose -f ryriigh-monero-merchant/docker-compose.yml config` with representative Umbrel env vars.
- Community store `docker compose -f ryriigh-monero-merchant/docker-compose.yml build backend --quiet`.
- PR package `docker compose -f umbrel/docker-compose.yml config` with representative Umbrel env vars.
- PR backend `docker build -f backend/Dockerfile backend`.
- `go test ./...` for `backend` via `golang:1.23-alpine` container.
- Re-ran backend tests and Umbrel compose config after adding the POS connection details card.
- Store repo synced through commit `01ba30a` so the Community App Store URL includes the same POS connection details card.
- `sh -n` for the Umbrel shell scripts.

Notes:
- Existing root `docker-compose.yml`, `Makefile`, and VPS install flow are left unchanged.
- For official app-store submission, the backend can later be published as a pinned multi-arch image and the `build:` block swapped for an immutable image digest.
