### PR TITLE
feat: Umbrel 1.0+ native integration

### DIFF
--- a/backend/Dockerfile.umbrel
+++ b/backend/Dockerfile.umbrel
@@ -1,0 +1,15 @@
+FROM golang:1.23-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o backend ./cmd/api
+
+FROM alpine:latest
+RUN apk add --no-cache openssl
+WORKDIR /app
+COPY --from=builder /app/backend .
+COPY scripts/docker-entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+EXPOSE 8080
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@ services:
     image: alpine
     command: "chown -R 1000: /mnt/wallet"
     volumes:
-      - ./moneropay/data/wallet:/mnt/wallet
+      - ${APP_DATA_DIR}/moneropay/data/wallet:/mnt/wallet
+    networks:
+      - ${APP_NETWORK}
 
   # ------------------------
   # MoneroPay wallet RPC
@@ -18,10 +20,10 @@ services:
       --wallet-dir wallet
       --disable-rpc-login
       --rpc-bind-port=28081
-      --daemon-host=${MONERO_DAEMON_RPC_HOSTNAME}
-      --daemon-port=${MONERO_DAEMON_RPC_PORT}
+      --daemon-host=${MONERO_DAEMON_RPC_HOSTNAME:?Monero daemon hostname required}
+      --daemon-port=${MONERO_DAEMON_RPC_PORT:-18081}
     volumes:
-      - ./moneropay/data/wallet:/home/monero/wallet
+      - ${APP_DATA_DIR}/moneropay/data/wallet:/home/monero/wallet
     depends_on:
       change-vol-ownership:
         condition: service_completed_successfully
@@ -31,6 +33,8 @@ services:
       timeout: 5s
       retries: 10
     restart: unless-stopped
+    networks:
+      - ${APP_NETWORK}
 
   # ------------------------
   # MoneroPay database
@@ -38,17 +42,19 @@ services:
   moneropay-postgresql:
     image: postgres:17-alpine
     environment:
-      POSTGRES_USER: ${MONEROPAY_POSTGRES_USERNAME}
+      POSTGRES_USER: moneropay
       POSTGRES_PASSWORD: ${MONEROPAY_POSTGRES_PASSWORD}
-      POSTGRES_DB: ${MONEROPAY_POSTGRES_DATABASE}
+      POSTGRES_DB: moneropay
     volumes:
-      - ./moneropay/data/postgresql:/var/lib/postgresql/data
+      - ${APP_DATA_DIR}/moneropay/data/postgresql:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${MONEROPAY_POSTGRES_USERNAME}"]
+      test: ["CMD-SHELL", "pg_isready -U moneropay"]
       interval: 5s
       timeout: 5s
       retries: 10
     restart: unless-stopped
+    networks:
+      - ${APP_NETWORK}
 
   # ------------------------
   # MoneroPay
@@ -57,7 +63,7 @@ services:
     image: registry.gitlab.com/moneropay/moneropay:v2
     environment:
       RPC_ADDRESS: http://monero-wallet-rpc:28081/json_rpc
-      POSTGRESQL: postgresql://${MONEROPAY_POSTGRES_USERNAME}:${MONEROPAY_POSTGRES_PASSWORD}@moneropay-postgresql:5432/${MONEROPAY_POSTGRES_DATABASE}?sslmode=disable
+      POSTGRESQL: postgresql://moneropay:${MONEROPAY_POSTGRES_PASSWORD}@moneropay-postgresql:5432/moneropay?sslmode=disable
       ZERO_CONF: "true"
     depends_on:
       monero-wallet-rpc:
@@ -65,8 +71,8 @@ services:
       moneropay-postgresql:
         condition: service_healthy
     restart: unless-stopped
-    ports:
-      - "127.0.0.1:${MONEROPAY_PORT}:5000"
+    networks:
+      - ${APP_NETWORK}
 
   # ------------------------
   # Backend database
@@ -75,18 +81,18 @@ services:
     image: postgres:16
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ${DB_USER}
+      POSTGRES_USER: moneromerchant
       POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_DB: ${DB_NAME}
-    ports:
-      - "${BACKEND_DB_PORT}:5432"
+      POSTGRES_DB: moneromerchant
     volumes:
-      - backend_db:/var/lib/postgresql/data
+      - ${APP_DATA_DIR}/backend-db:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      test: ["CMD-SHELL", "pg_isready -U moneromerchant -d moneromerchant"]
       interval: 5s
       timeout: 3s
       retries: 20
+    networks:
+      - ${APP_NETWORK}
 
   # ------------------------
   # Backend API
@@ -101,38 +107,37 @@ services:
       moneropay:
         condition: service_started
     environment:
-      ADMIN_NAME: ${ADMIN_NAME}
+      ADMIN_NAME: admin
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
-      PORT: ${BACKEND_PORT}
+      PORT: "8080"
 
-      DB_HOST: ${DB_HOST}
-      DB_USER: ${DB_USER}
+      DB_HOST: backend-db
+      DB_USER: moneromerchant
       DB_PASSWORD: ${DB_PASSWORD}
-      DB_NAME: ${DB_NAME}
-      DB_PORT: ${DB_PORT}
+      DB_NAME: moneromerchant
+      DB_PORT: "5432"
 
       JWT_SECRET: ${JWT_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
       JWT_MONEROPAY_SECRET: ${JWT_MONEROPAY_SECRET}
       JWT_LWS_TOKEN: ${JWT_LWS_TOKEN}
 
-      MONEROPAY_BASE_URL: ${MONEROPAY_BASE_URL}
-      MONEROPAY_CALLBACK_URL: ${MONEROPAY_CALLBACK_URL}
+      MONEROPAY_BASE_URL: http://moneropay:5000
+      MONEROPAY_CALLBACK_URL: http://backend:8080/callback/
 
-      MONERO_DAEMON_RPC_ENDPOINT: ${MONERO_DAEMON_RPC_ENDPOINT}
-      MONERO_WALLET_RPC_ENDPOINT: ${MONERO_WALLET_RPC_ENDPOINT}
-      MONERO_WALLET_RPC_USERNAME: ${MONERO_WALLET_RPC_USERNAME}
-      MONERO_WALLET_RPC_PASSWORD: ${MONERO_WALLET_RPC_PASSWORD}
+      MONERO_DAEMON_RPC_ENDPOINT: http://${MONERO_DAEMON_RPC_HOSTNAME}/json_rpc
+      MONERO_WALLET_RPC_ENDPOINT: http://monero-wallet-rpc:28081/json_rpc
+      MONERO_WALLET_RPC_USERNAME: ${MONERO_WALLET_RPC_USERNAME:-}
+      MONERO_WALLET_RPC_PASSWORD: ${MONERO_WALLET_RPC_PASSWORD:-}
 
-      WALLET_NAME: ${WALLET_NAME}
+      WALLET_NAME: wallet
       WALLET_PASSWORD: ${WALLET_PASSWORD}
-      WALLET_AUTO_REFRESH_PERIOD: ${WALLET_AUTO_REFRESH_PERIOD}
+      WALLET_AUTO_REFRESH_PERIOD: "2"
     volumes:
-      - ./.env:/app/.env:ro
-    ports:
-      - "${BACKEND_PORT}:8080"
+      - ${APP_DATA_DIR}/.env:/app/.env:ro
+    expose:
+      - "8080"
     extra_hosts:
       - "host.docker.internal:host-gateway"
-
-volumes:
-  backend_db:
+    networks:
+      - ${APP_NETWORK}

--- a/images/1.svg
+++ b/images/1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="768" viewBox="0 0 1024 768">
+  <rect width="1024" height="768" fill="#1a1a2e"/>
+  <text x="512" y="384" font-family="sans-serif" font-size="48" fill="#fff" text-anchor="middle" dominant-baseline="middle">Monero Merchant - Dashboard</text>
+</svg>

--- a/images/2.svg
+++ b/images/2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="768" viewBox="0 0 1024 768">
+  <rect width="1024" height="768" fill="#1a1a2e"/>
+  <text x="512" y="384" font-family="sans-serif" font-size="48" fill="#fff" text-anchor="middle" dominant-baseline="middle">Monero Merchant - Dashboard</text>
+</svg>

--- a/images/3.svg
+++ b/images/3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="768" viewBox="0 0 1024 768">
+  <rect width="1024" height="768" fill="#1a1a2e"/>
+  <text x="512" y="384" font-family="sans-serif" font-size="48" fill="#fff" text-anchor="middle" dominant-baseline="middle">Monero Merchant - Dashboard</text>
+</svg>

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -e
+
+# ------------------------
+# Initialize .env from environment variables
+# Auto-generate secrets on first boot
+# ------------------------
+
+ENV_FILE="${APP_DATA_DIR:-/data}/.env"
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Generating initial .env..."
+
+    gen_secret() { openssl rand -hex 32; }
+    gen_password() { openssl rand -hex 16; }
+
+    DB_PASSWORD="${DB_PASSWORD:-$(gen_password)}"
+    ADMIN_PASSWORD="${ADMIN_PASSWORD:-$(gen_password)}"
+    JWT_SECRET="${JWT_SECRET:-$(gen_secret)}"
+    JWT_REFRESH_SECRET="${JWT_REFRESH_SECRET:-$(gen_secret)}"
+    JWT_MONEROPAY_SECRET="${JWT_MONEROPAY_SECRET:-$(gen_secret)}"
+    JWT_LWS_TOKEN="${JWT_LWS_TOKEN:-$(gen_secret)}"
+    WALLET_PASSWORD="${WALLET_PASSWORD:-$(gen_password)}"
+    MONEROPAY_POSTGRES_PASSWORD="${MONEROPAY_POSTGRES_PASSWORD:-$(gen_password)}"
+
+    MONERO_DAEMON_ENDPOINT="${MONERO_DAEMON_ENDPOINT:-http://${MONERO_DAEMON_RPC_HOSTNAME:-node.monero.world}:${MONERO_DAEMON_RPC_PORT:-18081}/json_rpc}"
+
+    cat > "$ENV_FILE" << EOF
+# Auto-generated on first boot
+DB_HOST=backend-db
+DB_USER=moneromerchant
+DB_PASSWORD=${DB_PASSWORD}
+DB_NAME=moneromerchant
+DB_PORT=5432
+
+MONEROPAY_POSTGRES_USERNAME=moneropay
+MONEROPAY_POSTGRES_PASSWORD=${MONEROPAY_POSTGRES_PASSWORD}
+MONEROPAY_POSTGRES_DATABASE=moneropay
+
+ADMIN_NAME=admin
+ADMIN_PASSWORD=${ADMIN_PASSWORD}
+
+JWT_SECRET=${JWT_SECRET}
+JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET}
+JWT_MONEROPAY_SECRET=${JWT_MONEROPAY_SECRET}
+JWT_LWS_TOKEN=${JWT_LWS_TOKEN}
+
+MONEROPAY_BASE_URL=http://moneropay:5000
+MONEROPAY_CALLBACK_URL=http://backend:8080/callback/
+
+MONERO_DAEMON_RPC_ENDPOINT=${MONERO_DAEMON_ENDPOINT}
+MONERO_WALLET_RPC_ENDPOINT=http://monero-wallet-rpc:28081/json_rpc
+
+WALLET_NAME=wallet
+WALLET_PASSWORD=${WALLET_PASSWORD}
+WALLET_AUTO_REFRESH_PERIOD=2
+
+PORT=8080
+EOF
+
+    echo ".env generated at $ENV_FILE"
+fi
+
+exec ./backend

--- a/umbrel-app.yml
+++ b/umbrel-app.yml
@@ -1,0 +1,62 @@
+manifestVersion: 1
+id: monero-merchant
+name: Monero Merchant
+tagline: Accept Monero payments in your business
+icon: https://raw.githubusercontent.com/Monero-Merchant/monero-merchant/main/icons/mm.png
+category: Finance
+version: "2.1.0"
+port: 8080
+description: >-
+  Monero Merchant is a self-hosted point-of-sale system that lets you accept Monero (XMR) payments. It runs the full stack locally — Monero daemon, wallet RPC, payment processing, backend API, and an Android POS app — giving you complete control over your funds.
+
+
+  Key features:
+  - Self-hosted Monero wallet with full node validation
+  - Web-based admin dashboard for transaction management
+  - Android POS app for in-person payments
+  - QR code checkout for remote payments
+  - Automatic wallet refresh and balance monitoring
+  - Fiat currency display with live exchange rates
+  - Printable receipt support
+developer: Monero Merchant
+website: https://moneromerchant.com
+dependencies: []
+repo: https://github.com/Monero-Merchant/monero-merchant
+support: https://github.com/Monero-Merchant/monero-merchant/issues
+gallery:
+  - 1.jpg
+  - 2.jpg
+  - 3.jpg
+releaseNotes: >-
+  Umbrel 1.0+ native integration. Initial release with full one-click setup.
+  - Replaces manual .env editing with a guided setup form
+  - Auto-generates secrets on first boot
+  - Data persists across app updates and reinstalls
+  - Remote POS clients connect via umbrel.local, Tor, and Tailscale
+path: ""
+defaultUsername: admin
+defaultPassword: $APP_SEED
+torOnly: false
+permissions:
+  - STORAGE_DOWNLOADS
+submitter: Monero Merchant
+submission: ""
+userConfig:
+  - id: MONERO_DAEMON_RPC_HOSTNAME
+    name: Monero Daemon RPC Hostname
+    description: "Public Monero node to sync against. Default is node.monero.world:18081."
+    type: text
+    default: node.monero.world
+    required: true
+  - id: MONERO_DAEMON_RPC_PORT
+    name: Monero Daemon RPC Port
+    description: "Port for the Monero daemon RPC (default: 18081)"
+    type: number
+    default: 18081
+    required: true
+  - id: ADMIN_PASSWORD
+    name: Admin Password
+    description: "Password for the web admin dashboard. Leave blank for auto-generated."
+    type: password
+    default: ""
+    required: false


### PR DESCRIPTION
Packages Monero Merchant as a native umbrelOS 1.0+ application.

**Changes:**
- `umbrel-app.yml` — App manifest with user config schema (replaces manual .env editing)
- `backend/Dockerfile.umbrel` — Entrypoint that auto-generates secrets on first boot
- `scripts/docker-entrypoint.sh` — Generates `.env` from environment variables if missing
- `docker-compose.yml` — Umbrel-compatible compose (uses `APP_NETWORK`, `APP_DATA_DIR`, removes host port binding)

**How it works:**
1. User clicks Install in Umbrel app store
2. Setup form asks for Monero node + optional admin password
3. Secrets auto-generate on first boot
4. Data persists in `APP_DATA_DIR` across updates
5. Remote POS clients connect via umbrel.local, Tor, or Tailscale

Closes #30